### PR TITLE
Fix: Update PG error message to include Jerry prefix

### DIFF
--- a/src/lib/pg.ts
+++ b/src/lib/pg.ts
@@ -58,7 +58,7 @@ class PG extends Participant {
       await this.send(prompt, stream);
     } catch (err) {
       stream.markdown(
-        "🤔 I can't find the schema for the database. Please check the connection string with `/conn`"
+        "Jerry 🤔 I can't find the schema for the database. Please check the connection string with `/conn`"
       );
     }
   }


### PR DESCRIPTION
## Description
This pull request updates the error message in the pg.ts file to add "Jerry" at the beginning of the error message text when schema information is not found.

## Changes Made
- Modified the error message in the defaultResponse method of pg.ts to include "Jerry" as a prefix
- Enhanced user experience by personalizing error messages

## Testing
- Verified the change is correctly implemented in the code
- Error message now shows "Jerry 🤔 I can't find the schema for the database..." instead of just "🤔 I can't find the schema for the database..."

## Related Issues
This PR addresses the requirement to customize error messages with a personal identifier.

## Screenshots
N/A - Text change only